### PR TITLE
育て屋前で自転車に乗るタイミングの調整

### DIFF
--- a/examples/pokemon/auto_hatching/auto_hatching.ino
+++ b/examples/pokemon/auto_hatching/auto_hatching.ino
@@ -28,10 +28,10 @@ void getEggFromBreeder(){
     pushButton(Button::PLUS, 1000);
     tiltJoystick(0, 0, 100, 0, 2000);
     tiltJoystick(30, -100, 0, 0, 2000);
-    pushButton(Button::PLUS, 1000);
     // 育て屋さんから卵をもらう
     pushButton(Button::A, 1000, 4);
     pushButton(Button::B, 500, 10);
+    pushButton(Button::PLUS, 1000);
 }
 
 // 初期位置(ハシノマはらっぱ)からぐるぐる走り回る


### PR DESCRIPTION
育て屋前で自転車に乗る際、周りの障害物を避けるように主人公が移動し、卵を受け取れないケースがあったため、自転車にのるタイミングを卵受け取りの後にしました

2020.5/20追記
原因は別にあるみたいです失礼しました